### PR TITLE
ci(release): Migrate to PyPI Trusted Publisher

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    permissions:
+      id-token: write
+      attestations: write
 
     strategy:
       matrix:
@@ -77,6 +80,5 @@ jobs:
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
-          skip_existing: true
+          attestations: true
+          skip-existing: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ make dev_docs       # concurrent rebuild+serve (GNU make -J)
 ## Coding Standards
 
 - Ruff handles formatting and linting; run the formatter before committing.
-- mypy runs in strict mode—annotate new code thoroughly and prefer `import typing as t` with namespace access.
+- mypy runs in strict mode—annotate new code thoroughly and prefer `import typing as t` with namespace access for stdlib; third-party packages may use `from X import Y`.
 - Docstrings follow NumPy style (pydocstyle via Ruff); keep complex examples in dedicated tests instead of long doctests.
 - Prefer `pathlib.Path` over `os.path`; use f-strings for interpolation; keep Python ≥3.9 compatibility in mind.
 

--- a/CHANGES
+++ b/CHANGES
@@ -10,7 +10,9 @@ $ pip install --user --upgrade --pre pytest-pgsnap
 
 ## pytest-pgsnap 0.0.0 (unreleased)
 
-- _Add your latest changes from PRs here_
+### CI
+
+- Migrate to PyPI Trusted Publisher (#5)
 
 ### New features
 


### PR DESCRIPTION
## Summary
- Migrate PyPI publishing from API token to OIDC-based Trusted Publisher
- Enable package attestations for supply chain security
- Fix deprecated `skip_existing` parameter

## Setup Required
Before merging, configure the trusted publisher on PyPI:
1. Visit: https://pypi.org/manage/project/pytest-pgsnap/settings/publishing/
2. Add publisher with:
   - Owner: `tony`
   - Repository: `pytest-pgsnap`
   - Workflow: `tests.yml`